### PR TITLE
Revert "Bump moment from 2.29.1 to 2.29.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@nextcloud/l10n": "1.4.1",
         "core-js": "3.18.2",
         "jed": "^1.1.1",
-        "moment": "2.29.2",
+        "moment": "2.29.1",
         "node-gettext": "^3.0.0"
       },
       "devDependencies": {
@@ -10772,9 +10772,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
       "engines": {
         "node": "*"
       }
@@ -22719,9 +22719,9 @@
       }
     },
     "moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@nextcloud/l10n": "1.4.1",
     "core-js": "3.18.2",
     "jed": "^1.1.1",
-    "moment": "2.29.2",
+    "moment": "2.29.1",
     "node-gettext": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts nextcloud/nextcloud-moment#505 in favour of https://github.com/nextcloud/nextcloud-moment/pull/506