### PR TITLE
fix(l10n): do not call addTranslation without translation

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -2,6 +2,6 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: lib/index.ts:25
+#: lib/index.ts:32
 msgid "seconds"
 msgstr ""

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,10 +11,17 @@ const translations = LOCALES
 
 moment.locale(locale)
 
-// Only update the locale of moment.js if it's available. Moment.js ships more locales than we
-// track in transifex, so we prefer the included translation. Always prefer our default english
-// translation.
-if (locale === 'en' || locale in translations) {
+// Always prefer our default english translation.
+if (locale === 'en') {
+	moment.updateLocale(moment.locale(), {
+		relativeTime: { s: 'seconds' },
+	})
+}
+
+// Only update the locale of moment.js if it's available.
+// Moment.js ships more locales than we track in transifex.
+// If there's a translation from transifex use it, otherwise keep the included translation.
+if (locale in translations) {
 	const gt = getGettextBuilder()
 		.setLanguage(locale)
 		.addTranslation(locale, translations[locale])


### PR DESCRIPTION
There is no translation for the `en` locale.
Use the string `seconds` directly.

Fixes https://github.com/nextcloud-libraries/nextcloud-l10n/issues/957